### PR TITLE
Removing the cmd directive

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -8,15 +8,12 @@ description: |
     components needed to run PostgreSQL in your Kubernetes
     cluster.
 license: Apache-2.0 # your application's SPDX license
-cmd:
-    - /usr/bin/setpriv
-    - --clear-groups
-    - --reuid
-    - postgres
-    - --regid
-    - postgres
-    - --
-    - /usr/bin/patroni
+services:
+    postgresql:
+        override: replace
+        command: patroni
+        user: postgres
+        group: postgres
 platforms: # The platforms this ROCK should be built on and run on
     amd64:
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -8,12 +8,6 @@ description: |
     components needed to run PostgreSQL in your Kubernetes
     cluster.
 license: Apache-2.0 # your application's SPDX license
-services:
-    postgresql:
-        override: replace
-        command: patroni
-        user: postgres
-        group: postgres
 platforms: # The platforms this ROCK should be built on and run on
     amd64:
 


### PR DESCRIPTION
# Issue
* [DPE-1657](https://warthogs.atlassian.net/browse/DPE-1657)
* Use ppas for patroni, pgbackrest and pgbouncer
* Remove deprecated cmd directive

# Solution

# Context

# Testing
Created a  draft pr canonical/postgresql-k8s-operator#149 using a test version of the rock

# Release Notes
Use ppas for patroni, pgbackrest and pgbouncer

[DPE-1657]: https://warthogs.atlassian.net/browse/DPE-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ