### PR TITLE
[DPE-1086] Add dependencies for postgis and pltcl plugins

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -66,20 +66,20 @@ parts:
             dpkg-query -W -f "${dpkg_ops}\n" \
             --root=${CRAFT_PROJECT_DIR}/../parts/postgresql-snap/layer/ \
             >> $CRAFT_PRIME/usr/share/rocks/dpkg.query
-            ln $CRAFT_PRIME/usr/share/postgresql/14/extension/postgis.control \
-            $CRAFT_PRIME/usr/share/postgresql/14/extension/postgis-3.control
-            ln $CRAFT_PRIME/usr/share/postgresql/14/extension/ \
-            address_standardizer.control $CRAFT_PRIME/usr/share/postgresql/ \
-            14/extension/address_standardizer-3.control
-            ln $CRAFT_PRIME/usr/share/postgresql/14/extension/ \
-            address_standardizer_data_us.control $CRAFT_PRIME/usr/share/ \
-            postgresql/14/extension/address_standardizer_data_us-3.control
-            ln $CRAFT_PRIME/usr/share/postgresql/14/extension/ \
-            postgis_raster.control $CRAFT_PRIME/usr/share/postgresql/14/ \
-            extension/postgis_raster-3.control
-            ln $CRAFT_PRIME/usr/share/postgresql/14/extension/ \
-            postgis_tiger_geocoder.control $CRAFT_PRIME/usr/share/ \
-            postgresql/14/extension/postgis_tiger_geocoder-3.control
-            ln $CRAFT_PRIME/usr/share/postgresql/14/extension/ \
-            postgis_topology.control $CRAFT_PRIME/usr/share/ \
-            postgresql/14/extension/postgis_topology-3.control
+            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/postgis-3.control \
+            $CRAFT_PRIME/usr/share/postgresql/14/extension/postgis.control
+            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/\
+            address_standardizer-3.control $CRAFT_PRIME/usr/share/postgresql/\
+            14/extension/address_standardizer.control
+            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/\
+            address_standardizer_data_us-3.control $CRAFT_PRIME/usr/share/\
+            postgresql/14/extension/address_standardizer_data_us.control
+            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/\
+            postgis_raster-3.control $CRAFT_PRIME/usr/share/postgresql/14/\
+            extension/postgis_raster.control
+            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/\
+            postgis_tiger_geocoder-3.control $CRAFT_PRIME/usr/share/\
+            postgresql/14/extension/postgis_tiger_geocoder.control
+            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/\
+            postgis_topology-3.control $CRAFT_PRIME/usr/share/\
+            postgresql/14/extension/postgis_topology.control

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -66,3 +66,20 @@ parts:
             dpkg-query -W -f "${dpkg_ops}\n" \
             --root=${CRAFT_PROJECT_DIR}/../parts/postgresql-snap/layer/ \
             >> $CRAFT_PRIME/usr/share/rocks/dpkg.query
+            ln $CRAFT_PRIME/usr/share/postgresql/14/extension/postgis.control \
+            $CRAFT_PRIME/usr/share/postgresql/14/extension/postgis-3.control
+            ln $CRAFT_PRIME/usr/share/postgresql/14/extension/ \
+            address_standardizer.control $CRAFT_PRIME/usr/share/postgresql/ \
+            14/extension/address_standardizer-3.control
+            ln $CRAFT_PRIME/usr/share/postgresql/14/extension/ \
+            address_standardizer_data_us.control $CRAFT_PRIME/usr/share/ \
+            postgresql/14/extension/address_standardizer_data_us-3.control
+            ln $CRAFT_PRIME/usr/share/postgresql/14/extension/ \
+            postgis_raster.control $CRAFT_PRIME/usr/share/postgresql/14/ \
+            extension/postgis_raster-3.control
+            ln $CRAFT_PRIME/usr/share/postgresql/14/extension/ \
+            postgis_tiger_geocoder.control $CRAFT_PRIME/usr/share/ \
+            postgresql/14/extension/postgis_tiger_geocoder-3.control
+            ln $CRAFT_PRIME/usr/share/postgresql/14/extension/ \
+            postgis_topology.control $CRAFT_PRIME/usr/share/ \
+            postgresql/14/extension/postgis_topology-3.control

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -80,7 +80,7 @@ parts:
                 ln -f postgis_topology-3.control postgis_topology.control
             popd
             # Required for postgis_raster and pltcl PostgreSQL extensions
-            export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$CRAFT_PRIME/usr/lib/\
-                $CRAFT_ARCH_TRIPLET/blas:$CRAFT_PRIME/usr/lib/\
-                $CRAFT_ARCH_TRIPLET/lapack"
-            export TCL_LIBRARY="$CRAFT_PRIME/usr/share/tcltk/tcl8.6"
+            export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${CRAFT_PRIME}/usr/lib/\
+                ${CRAFT_ARCH_TRIPLET}/blas:${CRAFT_PRIME}/usr/lib/\
+                ${CRAFT_ARCH_TRIPLET}/lapack"
+            export TCL_LIBRARY="${CRAFT_PRIME}/usr/share/tcltk/tcl8.6"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -69,7 +69,8 @@ parts:
             # PostgreSQL extensions
             pushd "${CRAFT_PRIME}/usr/share/postgresql/14/extension"
                 ln -f postgis-3.control postgis.control
-                ln -f address_standardizer-3.control address_standardizer.control
+                ln -f address_standardizer-3.control \
+                      address_standardizer.control
                 ln -f address_standardizer_data_us-3.control \
                       address_standardizer_data_us.control
                 ln -f postgis_raster-3.control postgis_raster.control
@@ -78,7 +79,6 @@ parts:
                 ln -f postgis_topology-3.control postgis_topology.control
                 ln -f postgis_topology-3.control postgis_topology.control
             popd
-            
             # Required for postgis_raster and pltcl PostgreSQL extensions
             export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CRAFT_PRIME/usr/lib/ \
                 $CRAFT_ARCH_TRIPLET/blas:$CRAFT_PRIME/usr/lib/ \

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -80,7 +80,7 @@ parts:
                 ln -f postgis_topology-3.control postgis_topology.control
             popd
             # Required for postgis_raster and pltcl PostgreSQL extensions
-            export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CRAFT_PRIME/usr/lib/ \
-                $CRAFT_ARCH_TRIPLET/blas:$CRAFT_PRIME/usr/lib/ \
-                $CRAFT_ARCH_TRIPLET/lapack
-            export TCL_LIBRARY=$CRAFT_PRIME/usr/share/tcltk/tcl8.6
+            export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$CRAFT_PRIME/usr/lib/\
+                $CRAFT_ARCH_TRIPLET/blas:$CRAFT_PRIME/usr/lib/\
+                $CRAFT_ARCH_TRIPLET/lapack"
+            export TCL_LIBRARY="$CRAFT_PRIME/usr/share/tcltk/tcl8.6"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -66,7 +66,8 @@ parts:
             dpkg-query -W -f "${dpkg_ops}\n" \
             --root=${CRAFT_PROJECT_DIR}/../parts/postgresql-snap/layer/ \
             >> $CRAFT_PRIME/usr/share/rocks/dpkg.query
-            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/postgis-3.control \
+            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/ \
+            postgis-3.control \
             $CRAFT_PRIME/usr/share/postgresql/14/extension/postgis.control
             ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/\
             address_standardizer-3.control $CRAFT_PRIME/usr/share/postgresql/\
@@ -83,3 +84,7 @@ parts:
             ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/\
             postgis_topology-3.control $CRAFT_PRIME/usr/share/\
             postgresql/14/extension/postgis_topology.control
+            export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CRAFT_PRIME/usr/lib/ \
+            $CRAFT_ARCH_TRIPLET/blas:$CRAFT_PRIME/usr/lib/ \
+            $CRAFT_ARCH_TRIPLET/lapack
+            export TCL_LIBRARY=$CRAFT_PRIME/usr/share/tcltk/tcl8.6

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -68,18 +68,19 @@ parts:
             >> $CRAFT_PRIME/usr/share/rocks/dpkg.query
             # PostgreSQL extensions
             pushd "${CRAFT_PRIME}/usr/share/postgresql/14/extension"
-            ln -f postgis-3.control postgis.control
-            ln -f address_standardizer-3.control address_standardizer.control
-            ln -f address_standardizer_data_us-3.control \
-            address_standardizer_data_us.control
-            ln -f postgis_raster-3.control postgis_raster.control
-            ln -f postgis_tiger_geocoder-3.control \
-            postgis_tiger_geocoder.control
-            ln -f postgis_topology-3.control postgis_topology.control
-            ln -f postgis_topology-3.control postgis_topology.control
+                ln -f postgis-3.control postgis.control
+                ln -f address_standardizer-3.control address_standardizer.control
+                ln -f address_standardizer_data_us-3.control \
+                      address_standardizer_data_us.control
+                ln -f postgis_raster-3.control postgis_raster.control
+                ln -f postgis_tiger_geocoder-3.control \
+                      postgis_tiger_geocoder.control
+                ln -f postgis_topology-3.control postgis_topology.control
+                ln -f postgis_topology-3.control postgis_topology.control
             popd
+            
             # Required for postgis_raster and pltcl PostgreSQL extensions
             export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CRAFT_PRIME/usr/lib/ \
-            $CRAFT_ARCH_TRIPLET/blas:$CRAFT_PRIME/usr/lib/ \
-            $CRAFT_ARCH_TRIPLET/lapack
+                $CRAFT_ARCH_TRIPLET/blas:$CRAFT_PRIME/usr/lib/ \
+                $CRAFT_ARCH_TRIPLET/lapack
             export TCL_LIBRARY=$CRAFT_PRIME/usr/share/tcltk/tcl8.6

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -66,7 +66,7 @@ parts:
             dpkg-query -W -f "${dpkg_ops}\n" \
             --root=${CRAFT_PROJECT_DIR}/../parts/postgresql-snap/layer/ \
             >> $CRAFT_PRIME/usr/share/rocks/dpkg.query
-            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/ \
+            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/\
             postgis-3.control \
             $CRAFT_PRIME/usr/share/postgresql/14/extension/postgis.control
             ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/\

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -22,6 +22,11 @@ parts:
             - ca-certificates
             - tzdata
             - logrotate
+            - libfreetype6
+            - libjson-c5
+            - libssh-4
+            - liblapack3
+            - libedit2
     non-root-user:
         plugin: nil
         after: [postgresql-snap]
@@ -79,8 +84,3 @@ parts:
                 ln -f postgis_topology-3.control postgis_topology.control
                 ln -f postgis_topology-3.control postgis_topology.control
             popd
-            # Required for postgis_raster and pltcl PostgreSQL extensions
-            export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${CRAFT_PRIME}/usr/lib/\
-                ${CRAFT_ARCH_TRIPLET}/blas:${CRAFT_PRIME}/usr/lib/\
-                ${CRAFT_ARCH_TRIPLET}/lapack"
-            export TCL_LIBRARY="${CRAFT_PRIME}/usr/share/tcltk/tcl8.6"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -66,24 +66,19 @@ parts:
             dpkg-query -W -f "${dpkg_ops}\n" \
             --root=${CRAFT_PROJECT_DIR}/../parts/postgresql-snap/layer/ \
             >> $CRAFT_PRIME/usr/share/rocks/dpkg.query
-            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/\
-            postgis-3.control \
-            $CRAFT_PRIME/usr/share/postgresql/14/extension/postgis.control
-            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/\
-            address_standardizer-3.control $CRAFT_PRIME/usr/share/postgresql/\
-            14/extension/address_standardizer.control
-            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/\
-            address_standardizer_data_us-3.control $CRAFT_PRIME/usr/share/\
-            postgresql/14/extension/address_standardizer_data_us.control
-            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/\
-            postgis_raster-3.control $CRAFT_PRIME/usr/share/postgresql/14/\
-            extension/postgis_raster.control
-            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/\
-            postgis_tiger_geocoder-3.control $CRAFT_PRIME/usr/share/\
-            postgresql/14/extension/postgis_tiger_geocoder.control
-            ln -f $CRAFT_PRIME/usr/share/postgresql/14/extension/\
-            postgis_topology-3.control $CRAFT_PRIME/usr/share/\
-            postgresql/14/extension/postgis_topology.control
+            # PostgreSQL extensions
+            pushd "${CRAFT_PRIME}/usr/share/postgresql/14/extension"
+            ln -f postgis-3.control postgis.control
+            ln -f address_standardizer-3.control address_standardizer.control
+            ln -f address_standardizer_data_us-3.control \
+            address_standardizer_data_us.control
+            ln -f postgis_raster-3.control postgis_raster.control
+            ln -f postgis_tiger_geocoder-3.control \
+            postgis_tiger_geocoder.control
+            ln -f postgis_topology-3.control postgis_topology.control
+            ln -f postgis_topology-3.control postgis_topology.control
+            popd
+            # Required for postgis_raster and pltcl PostgreSQL extensions
             export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CRAFT_PRIME/usr/lib/ \
             $CRAFT_ARCH_TRIPLET/blas:$CRAFT_PRIME/usr/lib/ \
             $CRAFT_ARCH_TRIPLET/lapack


### PR DESCRIPTION
Added symlinks for postgis plugins:
- address_standardizer
- address_standardizer_data_us
- postgis_raster
- postgis_tiger_geocoder
- postgis_topology
- postgis

Added environment variables required by `postgis_raster` and `pltcl`:
- LD_LIBRARY_PATH
- TCL_LIBRARY