### PR TITLE
[DPE-6344] Add charm scripts dependencies

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -28,6 +28,16 @@ parts:
             - libssh-4
             - liblapack3
             - libedit2
+    non-charm-packages:
+        plugin: nil
+        after: [postgresql-snap]
+        build-packages:
+            - libpq-dev
+            - libldap2-dev
+            - libsasl2-dev
+            - python3-dev
+        overlay-script: |
+            python3 -m pip install --no-cache-dir "postgresql-ldap-sync==0.2.0"
     non-root-user:
         plugin: nil
         after: [postgresql-snap]

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -27,6 +27,7 @@ parts:
             - libjson-c5
             - libssh-4
             - liblapack3
+            - libldap-2.5-0
             - libedit2
     non-charm-packages:
         plugin: nil


### PR DESCRIPTION
This PR adds the newly created [postgresql-ldap-sync](https://github.com/canonical/postgresql-ldap-sync) package to the PostgreSQL rock, so the upcoming LDAP sync **stand-alone script** (not part of the charm logic) will be able to import it and leverage its utilities.

**Disclaimer:**

This is my first time extending a `rockcraft.yaml` file, so please, review carefully. I made sure the added dependency can be imported after building + running the OCI image locally, and spawning a Python shell within.