### PR TITLE
[DPE-6344] Add charm scripts dependencies (II)

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -33,6 +33,7 @@ parts:
             - libjson-c5
             - libssh-4
             - liblapack3
+            - libldap-common
             - libldap-2.5-0
             - libedit2
         override-build: |

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -37,7 +37,7 @@ parts:
             - libldap-2.5-0
             - libedit2
         override-build: |
-            python3 -m pip install --no-cache-dir "postgresql-ldap-sync==0.2.0"
+            python3 -m pip install --no-cache-dir "postgresql-ldap-sync==0.2.1"
     non-root-user:
         plugin: nil
         after: [postgresql-snap]

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -19,6 +19,12 @@ parts:
             - charmed-postgresql/14/edge
         stage-packages:
             - python3
+            - python3-dev
+            - python3-pip
+        build-packages:
+            - libpq-dev
+            - libldap2-dev
+            - libsasl2-dev
         overlay-packages:
             - ca-certificates
             - tzdata
@@ -29,15 +35,7 @@ parts:
             - liblapack3
             - libldap-2.5-0
             - libedit2
-    non-charm-packages:
-        plugin: nil
-        after: [postgresql-snap]
-        build-packages:
-            - libpq-dev
-            - libldap2-dev
-            - libsasl2-dev
-            - python3-dev
-        overlay-script: |
+        override-build: |
             python3 -m pip install --no-cache-dir "postgresql-ldap-sync==0.2.0"
     non-root-user:
         plugin: nil


### PR DESCRIPTION
This PR fixes the changes introduced in PR https://github.com/canonical/charmed-postgresql-rock/pull/78 by moving the PyPi packages installation to the `override-build` section, instead of the `overlay-script` one (which does not persist contents). I tried doing the installation of PyPi packages in a separate Rockcraft _part_, but I could not manage to get it to work. The error being:

```log
Failed to stage: parts list the same file with different contents or permissions:
    usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0
```

### Additional changes:
- Bumped `postgresql-ldap-sync` version to `0.2.1` (depends on [this PR](https://github.com/canonical/postgresql-ldap-sync/pull/9)).