### PR TITLE
[DPE-6344] Remove charm scripts dependencies

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -27,18 +27,7 @@ parts:
             - libjson-c5
             - libssh-4
             - liblapack3
-            - libldap-2.5-0
             - libedit2
-    non-charm-packages:
-        plugin: nil
-        after: [postgresql-snap]
-        build-packages:
-            - libpq-dev
-            - libldap2-dev
-            - libsasl2-dev
-            - python3-dev
-        overlay-script: |
-            python3 -m pip install --no-cache-dir "postgresql-ldap-sync==0.2.0"
     non-root-user:
         plugin: nil
         after: [postgresql-snap]


### PR DESCRIPTION
This PR reverts changes introduced in PR https://github.com/canonical/charmed-postgresql-rock/pull/78, as they need to be moved one abstraction layer lower (rock -> snap), so that both the VM and K8s charms to support LDAP.