### PR TITLE
[MISC] Isolate snap installation

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -17,6 +17,13 @@ parts:
         plugin: nil
         stage-snaps:
             - charmed-postgresql/14/edge
+        stage:
+            - "-bin/python*"
+            - "-lib"
+            - "-lib64"
+    postgresql-debs:
+        plugin: nil
+        after: [postgresql-snap]
         stage-packages:
             - python3
         overlay-packages:
@@ -30,7 +37,7 @@ parts:
             - libedit2
     non-root-user:
         plugin: nil
-        after: [postgresql-snap]
+        after: [postgresql-debs]
         overlay-script: |
             # Create a user in the $CRAFT_OVERLAY chroot
             groupadd -R $CRAFT_OVERLAY -g  584788 postgres


### PR DESCRIPTION
This PR isolates the installation of the PostgreSQL snap, in order to support _snap-installed Python packages_ in the rock.

This is an alternative to the way @tigarmo recommended, which relied on unpacking snap contents on a controlled folder, instead of overlying everything on the rock. After a conversation with Alex, we decided for this approach in order to stream-line the process instead of revisiting a 2 year old decision.

### Additional notes
This is the approach Tiago recommended:

```diff
     postgresql-snap:
         plugin: nil
         stage-snaps:
             - charmed-postgresql/14/edge
+        organize:
+            "bin": "app/bin"
+            "lib": "app/lib"
+            "lib64": "app/lib64"
+            "pyvenv.cfg": "app/"
+    postgresql-debs:
+        plugin: nil
+        after: [postgresql-snap]
```