### PR TITLE
DPE-8296 Bump PostgreSQL to 14.19

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-postgresql
 base: ubuntu@22.04
-version: '14.18'
+version: '14.19'
 summary: PostgreSQL in a rock.
 description: |
     The PostgreSQL rock is created using the


### PR DESCRIPTION
## Issue

The rock ships non-latest PostgreSQL 14.18.

## Solution

Bump PostgreSQL to 14.19.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
