### PR TITLE
DPE-8296 Bump PostgreSQL to 16.10 + update rockcraft.yaml + SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security policy
+
+## What qualifies as a security issue
+
+Credentials leakage, outdated dependencies with known vulnerabilities, and
+other issues that could lead to unprivileged or unauthorized access to the
+database or the system.
+
+## Reporting a vulnerability
+
+The easiest way to report a security issue is through
+[GitHub](https://github.com/canonical/charmed-postgresql-rock/security/advisories/new). See
+Privately reporting a security
+vulnerability](<https://docs.github.com/en/code-securitysecurity-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability>)
+for instructions.
+
+The repository admins will be notified of the issue and will work with you
+to determine whether the issue qualifies as a security issue and, if so, in
+which component. We will then handle figuring out a fix, getting a CVE
+assigned and coordinating the release of the fix.
+
+The [Ubuntu Security disclosure and embargo
+policy](https://ubuntu.com/security/disclosure-policy) contains more
+information about what you can expect when you contact us, and what we
+expect from you.

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-postgresql
 base: ubuntu@24.04
-version: '16.9'
+version: '16.10'
 summary: PostgreSQL in a rock.
 description: |
     The PostgreSQL rock is created using the

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: charmed-postgresql
 base: ubuntu@24.04
 version: '16.10'
-summary: PostgreSQL in a rock.
+summary: Charmed PostgreSQL rock OCI
 description: |
     The PostgreSQL rock is created using the
     charmed-postgresql-snap and includes all of the
@@ -13,15 +13,14 @@ platforms:
     arm64:
 
 parts:
-    postgresql-snap:
+    charmed-postgresql:
         plugin: nil
         stage-snaps:
             - charmed-postgresql/16/edge
-        stage-packages:
-            - python3
         overlay-packages:
             - ca-certificates
             - tzdata
+            - python3
             - logrotate
             - libfreetype6
             - libjson-c5
@@ -32,21 +31,17 @@ parts:
             - libevent-2.1-7t64
     non-root-user:
         plugin: nil
-        after: [postgresql-snap]
+        after:
+            - charmed-postgresql
         overlay-script: |
             # Create a user in the $CRAFT_OVERLAY chroot
             groupadd -R $CRAFT_OVERLAY -g  584788 postgres
-            useradd -R $CRAFT_OVERLAY -M -r -g postgres -u 584788 postgres
+            useradd -R $CRAFT_OVERLAY -m -r -g postgres -u 584788 postgres
         override-prime: |
             craftctl default
-            # This is only needed until this bug is resolved with pebble
-            # https://github.com/canonical/pebble/issues/189
-            mkdir -p $CRAFT_PRIME/home/postgres
             array=( .bash_logout .bashrc .profile )
-            for i in "${array[@]}"
-            do
+            for i in "${array[@]}"; do
                 cp /etc/skel/"$i" $CRAFT_PRIME/home/postgres
-                chown 584788 $CRAFT_PRIME/home/postgres/"$i"
             done
             chown -R 584788 $CRAFT_PRIME/var/log/pgbackrest
             chown -R 584788 $CRAFT_PRIME/var/log/postgresql


### PR DESCRIPTION
## Issue

The charm ships non-latest PostgreSQL 16.9.

## Solution

Bump PostgreSQL to 16.10.
For some reason, the rock is no longer build-able after the version bump:
```
Staging postgresql-snap (required to build 'non-root-user')
Failed to stage: parts list the same file or directory with different contents or permissions.
Detailed information: 
Part 'postgresql-snap' and the overlay of part 'postgresql-snap' list the following files, but with different contents or permissions:
    etc/localtime
    usr/share/zoneinfo/localtime
Failed to run rockcraft in instance
Full execution log: '/home/runner/.local/state/rockcraft/log/rockcraft-20250910-113124.371898.log'
```
Removing tzdata from rock helps to mute/fix those error, but it was introduced for the reason in https://github.com/canonical/charmed-postgresql-rock/pull/8.

Another approach has been choosen to unblock version bump:
after sync yaml with a bit newer charmed-mysql-rock (which builds well),
the charmed-postgtesql-rock has been built successfully and pass all test.

The strange new warning appears: `unknown argument ignored: lazytime`  ([reported](https://github.com/canonical/rockcraft/issues/964) to the Rock team).
Also during the sync with MySQL introduced SECURITY.md and removed no longer necessary Pebble issue workaround.
