### PR TITLE
Add Trivy scan

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -4,7 +4,7 @@ name: Trivy Security Scanner
 on:
   push:
     branches:
-      - 16-24.04
+      - 14-22.04
   pull_request:
 
 permissions:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,0 +1,53 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Trivy Security Scanner
+on:
+  push:
+    branches:
+      - 16-24.04
+  pull_request:
+
+permissions:
+  contents: read  # Set the GITHUB_TOKEN permissions to read-only
+
+jobs:
+  build:
+    name: Build rock
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v35.0.2
+  scan:
+    name: Trivy scan
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v5
+      - name: Install required dependencies
+        run: |
+          # rockcraft
+          sudo snap install rockcraft --classic --edge
+
+          # yq
+          sudo snap install yq
+      - name: Download rock package(s)
+        uses: actions/download-artifact@v5
+        with:
+          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
+          merge-multiple: true
+      - name: Import locally
+        run: |
+          full_version="$(yq .version rockcraft.yaml)"
+          sudo rockcraft.skopeo --insecure-policy copy \
+              "oci-archive:charmed-postgresql_${full_version}_amd64.rock" \
+              "docker-daemon:trivy/charmed-postgresql:test"
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: "trivy/charmed-postgresql:test"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "HIGH,CRITICAL"
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
## Issue
There is no automated vulnerability scan.

## Solution
Add Trivy scan. Ported from https://github.com/canonical/charmed-mysql-rock/pull/55.

Results will be reported at https://github.com/canonical/charmed-postgresql-rock/security/code-scanning?query=pr%3A175+is%3Aopen.