### PR TITLE
[DPE-9356] fix: update peer CA certificate path to /var/lib/pg/data/

### DIFF
--- a/local/scripts/self-signed-checker.py
+++ b/local/scripts/self-signed-checker.py
@@ -9,7 +9,7 @@ from ssl import create_default_context
 from urllib.request import urlopen
 
 context = create_default_context()
-context.load_verify_locations(cafile="/var/lib/postgresql/data/peer_ca.pem")
+context.load_verify_locations(cafile="/var/lib/pg/data/peer_ca.pem")
 # Endpoint is set by the charm
 with urlopen(os.environ["ENDPOINT"], context=context) as response:  # noqa: S310
     # We want assert to exit the interpreter with an error


### PR DESCRIPTION
## Issue

The peer CA certificate path in `self-signed-checker.py` still references the old data directory (`/var/lib/postgresql/data/`), which doesn't follow what's defined in the spec [DA230](https://docs.google.com/document/d/1eCVf0OH0BZ6GAt9bhxhgObWubPWttn5IZa0GXVtdvJo/edit?tab=t.0).

## Solution

Update the `cafile` path in `local/scripts/self-signed-checker.py` from `/var/lib/postgresql/data/peer_ca.pem` to `/var/lib/pg/data/peer_ca.pem` to match the new data directory layout.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.