### PR TITLE
[DPE-9453] fix(ci): add security-events write permission for Trivy SARIF upload

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read  # Set the GITHUB_TOKEN permissions to read-only
+  security-events: write  # Required for uploading Trivy SARIF results
 
 jobs:
   build:


### PR DESCRIPTION
## Issue
We missed `security-events: write` in the trivy workflow. It's failing when we push to the `16-24.04` branch. It doesn't fail in PRs. I couldn't find an explicit mention in the docs that it's handled that differently.

## Solution
Add it for the workflow to work in the `push` trigger.

Tested on the following CI runs:
-> Failing without the permission: https://github.com/canonical/charmed-postgresql-rock/actions/runs/21960364590
-> Passing with the permission: https://github.com/canonical/charmed-postgresql-rock/actions/runs/21959976328