### PR TITLE
Remove conflicting overlay packages

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -25,8 +25,6 @@ parts:
             - logrotate
             - libfreetype6
             - libjson-c5
-            - libssh-4
-            - liblapack3
             - libedit2
     non-root-user:
         plugin: nil


### PR DESCRIPTION
# Issue:

The `rockcraft pack` fails with error:
```
Detailed information: 
Part 'postgresql-snap' and the overlay of part 'postgresql-snap' list the following files, but with different contents or permissions:
    usr/lib/x86_64-linux-gnu/libgfortran.so.5.0.0
    usr/lib/x86_64-linux-gnu/libquadmath.so.0.0.0
```

# Solution:

Backporting 9672b58c86c32993f3e26dbbe25df7e8d628b311 from 16-24.04 to 14-22.04.