### PR TITLE
[DPE-9455] Bump PostgreSQL to 14.22

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-postgresql
 base: ubuntu@22.04
-version: '14.20'
+version: '14.22'
 summary: PostgreSQL in a rock.
 description: |
     The PostgreSQL rock is created using the


### PR DESCRIPTION
# Issue:

We ship outdated PostgreSQL 14.20.

# Solution:

Update PostgreSQL to 14.22.