### PR TITLE
[DPE-9492] Trivy checks (14-22.04)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,10 +2,6 @@
 # See LICENSE file for licensing details.
 name: Release to GHCR
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 on:
   push:
     branches:
@@ -65,3 +61,12 @@ jobs:
           name: sbom-${{ needs.ci-tests.outputs.artifact-prefix }}
           path: '*.spdx.json'
           if-no-files-found: error
+  trivy:
+    needs:
+      # Checks the pushed tag
+      - release
+    permissions:
+      contents: read  # Set the GITHUB_TOKEN permissions to read-only
+      security-events: write  # Required for uploading Trivy SARIF results
+    name: Trivy Scan
+    uses: ./.github/workflows/trivy.yaml

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -5,7 +5,6 @@ on:
   workflow_call:
 
 permissions:
-  contents: read  # Set the GITHUB_TOKEN permissions to read-only
   security-events: write  # Required for uploading Trivy SARIF results
 
 jobs:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -2,22 +2,15 @@
 # See LICENSE file for licensing details.
 name: Trivy Security Scanner
 on:
-  push:
-    branches:
-      - 14-22.04
-  pull_request:
+  workflow_call:
 
 permissions:
   contents: read  # Set the GITHUB_TOKEN permissions to read-only
   security-events: write  # Required for uploading Trivy SARIF results
 
 jobs:
-  build:
-    name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v42.0.1
   scan:
     name: Trivy scan
-    needs: build
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
@@ -27,23 +20,16 @@ jobs:
           # rockcraft
           sudo snap install rockcraft --classic --edge
 
-          # yq
-          sudo snap install yq
-      - name: Download rock package(s)
-        uses: actions/download-artifact@v8
-        with:
-          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
-          merge-multiple: true
-      - name: Import locally
+          # jq
+          sudo snap install jq
+      - name: Find rock tag
+        id: rock-tag
         run: |
-          full_version="$(yq .version rockcraft.yaml)"
-          sudo rockcraft.skopeo --insecure-policy copy \
-              "oci-archive:charmed-postgresql_${full_version}_amd64.rock" \
-              "docker-daemon:trivy/charmed-postgresql:test"
+          echo "tag=$(rockcraft.skopeo list-tags docker://ghcr.io/canonical/charmed-postgresql | jq -r '.Tags | map(select(startswith("14.")))| max_by(split(".")[1] | split("-")[0] | tonumber)')" >> "$GITHUB_OUTPUT"
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
-          image-ref: "trivy/charmed-postgresql:test"
+          image-ref: "ghcr.io/canonical/charmed-postgresql:${{steps.rock-tag.outputs.tag }}"
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "HIGH,CRITICAL"


### PR DESCRIPTION
Port of https://github.com/canonical/charmed-postgresql-rock/pull/269.

Run trivy against the tip of the Docker repository.