### PR TITLE
[DPE-9492] Limit trivy severity (16-24.04)

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -32,6 +32,7 @@ jobs:
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "HIGH,CRITICAL"
+          limit-severities-for-sarif: true
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         if: always()


### PR DESCRIPTION
Enable the severity filter for the sarif file we generate.