### PR TITLE
[DPE-10012] Update version to 14.23

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -19,13 +19,13 @@ parts:
             - charmed-postgresql/14/edge
         stage-packages:
             - ca-certificates
-            - tzdata
             - logrotate
             - libfreetype6
             - libjson-c5
             - libedit2
             - libssh-4
             - python3
+            - tzdata
     non-root-user:
         plugin: nil
         after: [postgresql-snap]

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-postgresql
 base: ubuntu@22.04
-version: '14.22'
+version: '14.23'
 summary: PostgreSQL in a rock.
 description: |
     The PostgreSQL rock is created using the

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -18,8 +18,6 @@ parts:
         stage-snaps:
             - charmed-postgresql/14/edge
         stage-packages:
-            - python3
-        overlay-packages:
             - ca-certificates
             - tzdata
             - logrotate
@@ -27,6 +25,7 @@ parts:
             - libjson-c5
             - libedit2
             - libssh-4
+            - python3
     non-root-user:
         plugin: nil
         after: [postgresql-snap]


### PR DESCRIPTION
* Update Postgresql version 14.23.
* Mode  overlay-packages to stage-packages. Otherwise rockcraft 1.18+ can't build rock:
> Failed to copy '/root/stage/usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1': no such file or directory.
(dependencies with symlinks are missing in overlay-packages)