### PR TITLE
[DPE-10012] Move ca-certificates from stage- to overlay-packages

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -18,7 +18,6 @@ parts:
         stage-snaps:
             - charmed-postgresql/14/edge
         stage-packages:
-            - ca-certificates
             - logrotate
             - libfreetype6
             - libjson-c5
@@ -26,6 +25,9 @@ parts:
             - libssh-4
             - python3
             - tzdata
+        overlay-packages:
+            # pgBackRest can't acces S3 AWS/GCloud without it
+            - ca-certificates
     non-root-user:
         plugin: nil
         after: [postgresql-snap]


### PR DESCRIPTION
Otherwise AWS/GCloud backup integration tests fail on Charmed PostgreSQL K8s:
```
unit-postgresql-k8s-0: 12:12:01 ERROR unit.postgresql-k8s/0.juju-log non-zero exit code 95 executing 'pgbackrest', stdout='',
stderr="ERROR: [095]: unable to verify certificate presented by 'hidden.s3.amazonaws.com:443 (16.15.199.147)': [20] unable to get local issuer certificate\n
[CryptoError] on 6 retries from 628-5034ms: unable to verify certificate presented by 'hidden.s3.amazonaws.com:443 (16.15.199.147)': [20] unable to get local issuer certificate\n
[CryptoError] on 2 retries from 7403-11062ms: unable to verify certificate presented by 'hidden.s3.amazonaws.com:443 (16.15.223.28)': [20] unable to get local issuer certificate\n
[CryptoError] on retry at 16836ms: unable to verify certificate presented by 'hidden.s3.amazonaws.com:443 (52.216.32.225)': [20] unable to get local issuer certificate\n
[CryptoError] on retry at 26021ms: unable to verify certificate presented by 'hidden.s3.amazonaws.com:443 (52.216.51.57)': [20] unable to get local issuer certificate\n
[CryptoError] on retry at 40701ms: unable to verify certificate pre" [truncated] Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-postgresql-k8s-0/charm/src/backups.py", line 994, in _on_list_backups_action
    formatted_list = self._generate_backup_list_output()
  File "/var/lib/juju/agents/unit-postgresql-k8s-0/charm/src/backups.py", line 426, in _generate_backup_list_output
    for timeline, (_, timeline_id) in self._list_timelines().items():
  File "/var/lib/juju/agents/unit-postgresql-k8s-0/charm/src/backups.py", line 480, in _list_timelines
    output, _ = self._execute_command([
  File "/var/lib/juju/agents/unit-postgresql-k8s-0/charm/src/backups.py", line 331, in _execute_command
    return process.wait_output()
  File "/var/lib/juju/agents/unit-postgresql-k8s-0/charm/venv/lib/python3.10/site-packages/ops/pebble.py", line 1857, in wait_output
    raise ExecError[AnyStr](self._command, exit_code, out_value, err_value)
ops.pebble.ExecError: non-zero exit code 95 executing 'pgbackrest', stdout='', stderr="ERROR: [095]: unable to verify certificate ...
```

The commit partially reverts https://github.com/canonical/charmed-postgresql-rock/pull/326